### PR TITLE
make pest, make test, make pint これらのコマンドを IntelliJ IDEA の Run で実行したとき、出力内容の文字の色が失われないようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 CONTAINER_NAME=php
+
+# OS ごとに script を使い分ける
+ifeq ($(shell uname -s),Darwin)
+	PINT_SCRIPT = script /dev/null docker compose exec php ./vendor/bin/pint
+else
+	PINT_SCRIPT = script -q -c "docker compose exec php ./vendor/bin/pint" /dev/null
+endif
+
 .PHONY: up
 
 up:
@@ -19,7 +27,7 @@ pest:
 	docker compose exec $(CONTAINER_NAME) ./vendor/bin/pest --colors=always $(filter-out $@,$(MAKECMDGOALS))
 
 pint:
-	docker compose exec $(CONTAINER_NAME) ./vendor/bin/pint $(filter-out $@,$(MAKECMDGOALS))
+	$(PINT_SCRIPT) $(filter-out $@,$(MAKECMDGOALS))
 
 %:
 	@:


### PR DESCRIPTION
#77